### PR TITLE
Added redbox data for Canadaian payphone coin tones

### DIFF
--- a/dtmf_dolphin_data.c
+++ b/dtmf_dolphin_data.c
@@ -80,6 +80,17 @@ DTMFDolphinSceneData DTMFDolphinSceneDataRedboxUS = {
     }
 };
 
+DTMFDolphinSceneData DTMFDolphinSceneDataRedboxCA = {
+    .name = "Redbox (CA)",
+    .block = DTMF_DOLPHIN_TONE_BLOCK_REDBOX_CA,
+    .tone_count = 3,
+    .tones = {
+      {"Nickel",  2200.0, {0, 0, 5}, 1, 66, 0},
+      {"Dime",    2200.0, {1, 0, 5}, 2, 66, 66},
+      {"Quarter", 2200.0, {2, 0, 5}, 5, 33, 33},
+    }
+};
+
 DTMFDolphinSceneData DTMFDolphinSceneDataRedboxUK = {
     .name = "Redbox (UK)",
     .block = DTMF_DOLPHIN_TONE_BLOCK_REDBOX_UK,
@@ -115,6 +126,9 @@ void dtmf_dolphin_data_set_current_section(DTMFDolphinToneSection section) {
     case DTMF_DOLPHIN_TONE_BLOCK_REDBOX_US:
         current_scene_data = &DTMFDolphinSceneDataRedboxUS;
         break;
+    case DTMF_DOLPHIN_TONE_BLOCK_REDBOX_CA:
+        current_scene_data = &DTMFDolphinSceneDataRedboxCA;
+	break;
     case DTMF_DOLPHIN_TONE_BLOCK_REDBOX_UK:
         current_scene_data = &DTMFDolphinSceneDataRedboxUK;
         break;

--- a/dtmf_dolphin_data.c
+++ b/dtmf_dolphin_data.c
@@ -85,9 +85,9 @@ DTMFDolphinSceneData DTMFDolphinSceneDataRedboxCA = {
     .block = DTMF_DOLPHIN_TONE_BLOCK_REDBOX_CA,
     .tone_count = 3,
     .tones = {
-      {"Nickel",  2200.0, {0, 0, 5}, 1, 66, 0},
-      {"Dime",    2200.0, {1, 0, 5}, 2, 66, 66},
-      {"Quarter", 2200.0, {2, 0, 5}, 5, 33, 33},
+      {"Nickel",  2200.0, 0.0, {0, 0, 5}, 1, 66, 0},
+      {"Dime",    2200.0, 0.0, {1, 0, 5}, 2, 66, 66},
+      {"Quarter", 2200.0, 0.0, {2, 0, 5}, 5, 33, 33},
     }
 };
 


### PR DESCRIPTION
This PR is to add Canandian payphone coin tones into the program. I followed along with the existing code to add this data in and it should be accurate.

Information about Canadian payphone coin tones was found here: https://phonelosers.com/redbox/

Canadian coin tones are all 2200 Hz.
Nickels are one 66ms tone.
Dimes are 66ms on, 66ms off, 66ms on, 66ms off.
Quarters are 33ms on, 33ms off, repeated 5 times.